### PR TITLE
Configure Maven compiler for Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,14 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <release>${java.version}</release>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>${spring-boot.version}</version>


### PR DESCRIPTION
## Summary
- ensure project compiles against Java 21 by configuring maven-compiler-plugin with release 21

## Testing
- `mvn -e -ntp test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.3.2 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a960b3448321a45ce9e1ba5b7e17